### PR TITLE
Fix: 部活の404がVercelでハンドリングできていなかったので修正

### DIFF
--- a/pages/clubs/_id.vue
+++ b/pages/clubs/_id.vue
@@ -9,9 +9,11 @@ import { Context } from '@nuxt/types'
 
 export default {
   async asyncData (context: Context) {
-    const { app, params } = context
+    const { app, params, error } = context
     const response = await app.$microcms.get({
       endpoint: `clubs/${params.id}`
+    }).catch(() => {
+      error({ statusCode: 404, message: 'お探しの部活動・サークルが見つかりませんでした。' })
     })
     return {
       club: response


### PR DESCRIPTION
IDが存在しない時、ローカルだとclubがundefinedになる→何も出ないんですが、Vercelだと500エラーになってました。
取り急ぎエラーメッセージだけ出しました。