### PR TITLE
日付によって表示を切り替えるカウントダウンを追加

### DIFF
--- a/@types/vue2-flip-countdown.d.ts
+++ b/@types/vue2-flip-countdown.d.ts
@@ -1,0 +1,1 @@
+declare module 'vue2-flip-countdown'

--- a/components/Countdown.vue
+++ b/components/Countdown.vue
@@ -14,12 +14,13 @@ import dayjs from 'dayjs'
 dayjs.extend(require('dayjs/plugin/timezone'))
 dayjs.extend(require('dayjs/plugin/utc'))
 dayjs.tz.setDefault('Asia/Tokyo')
-const openDateEnv = process.env.OPEN_DATE
-const isEnvValid = dayjs(openDateEnv).isValid()
 let openDateInput = '2021-11-07 00:00:00'
+const openDateEnv = process.env.OPEN_DATE
+// nullを入れないと現在日時になってしまう
+const isEnvValid = dayjs(openDateEnv ?? null).isValid()
 // dayjsが環境変数を解釈できない場合、ハードコーディングされた日時を使う
 if (isEnvValid) {
-  openDateInput = process.env.OPEN_DATE
+  openDateInput = openDateEnv
 }
 
 export default {

--- a/components/Countdown.vue
+++ b/components/Countdown.vue
@@ -51,7 +51,7 @@ export default {
       // 差分を利用して、オープンの瞬間にカウントダウンを非表示にする
       // 重要: アロー関数はthisの参照先が変わるので使わないこと
       setTimeout(function () {
-        this.enableCountDown = false
+        window.location.reload()
       }, this.milliSecondsUntilOpen)
     },
     warnAboutEnv () {

--- a/components/Countdown.vue
+++ b/components/Countdown.vue
@@ -50,9 +50,11 @@ export default {
     closeCountDown () {
       // 差分を利用して、オープンの瞬間にカウントダウンを非表示にする
       // 重要: アロー関数はthisの参照先が変わるので使わないこと
-      setTimeout(function () {
-        window.location.reload()
-      }, this.milliSecondsUntilOpen)
+      if (this.enableCountDown) {
+        setTimeout(function () {
+          window.location.reload()
+        }, this.milliSecondsUntilOpen)
+      }
     },
     warnAboutEnv () {
       if (isEnvValid) {

--- a/components/Countdown.vue
+++ b/components/Countdown.vue
@@ -1,0 +1,66 @@
+<template>
+  <div v-if="enableCountDown" class="fixed top-0 left-0 z-50 w-screen h-screen bg-white flex flex-col gap-6 justify-center items-center">
+    <div class="font-bold text-xl">
+      学祭2021 サイトオープンまで
+    </div>
+    <client-only><FlipCountdown :deadline="openDateString" :labels="{days:'日', hours:'時間', minutes:'分', seconds:'秒'}" /></client-only>
+  </div>
+</template>
+
+<script>
+import FlipCountdown from 'vue2-flip-countdown'
+import dayjs from 'dayjs'
+// 以降の処理を日本時間基準に切り替える
+dayjs.extend(require('dayjs/plugin/timezone'))
+dayjs.extend(require('dayjs/plugin/utc'))
+dayjs.tz.setDefault('Asia/Tokyo')
+const openDateEnv = process.env.OPEN_DATE
+const isEnvValid = dayjs(openDateEnv).isValid()
+let openDateInput = '2021-11-07 00:00:00'
+// dayjsが環境変数を解釈できない場合、ハードコーディングされた日時を使う
+if (isEnvValid) {
+  openDateInput = process.env.OPEN_DATE
+}
+
+export default {
+  name: 'Countdown',
+  components: { FlipCountdown },
+
+  data () {
+    const openDate = dayjs(openDateInput)
+
+    // オープンまでのmsはマイナスになるが、以下の演算がわかりにくいためプラスにする
+    const milliSecondsUntilOpen = dayjs().diff(openDate, false) * -1
+
+    // カウトダウンタイマーのために文字列化する必要がある
+    // 詳細: https://github.com/philipjkim/vue2-flip-countdown
+    const openDateString = openDate.format('YYYY-MM-DD HH:mm:ss')
+    return {
+      openDateString,
+      milliSecondsUntilOpen,
+      enableCountDown: milliSecondsUntilOpen > 0
+    }
+  },
+  mounted () {
+    this.warnAboutEnv()
+    this.closeCountDown()
+  },
+  methods: {
+    closeCountDown () {
+      // 差分を利用して、オープンの瞬間にカウントダウンを非表示にする
+      // 重要: アロー関数はthisの参照先が変わるので使わないこと
+      setTimeout(function () {
+        this.enableCountDown = false
+      }, this.milliSecondsUntilOpen)
+    },
+    warnAboutEnv () {
+      if (isEnvValid) {
+        console.debug('オープン日時を環境変数から設定しました')
+      } else {
+        openDateEnv ? console.debug(`環境変数はYYYY-MM-DD HH:mm:ssで設定してください: ${openDateEnv}`) : console.debug('環境変数が設定されていません')
+      }
+      console.debug(`オープン日時: ${this.openDateString}`)
+    }
+  }
+}
+</script>

--- a/components/Countdown.vue
+++ b/components/Countdown.vue
@@ -14,7 +14,7 @@ import dayjs from 'dayjs'
 dayjs.extend(require('dayjs/plugin/timezone'))
 dayjs.extend(require('dayjs/plugin/utc'))
 dayjs.tz.setDefault('Asia/Tokyo')
-let openDateInput = '2021-11-07 00:00:00'
+let openDateInput = '2021-11-06 00:00:00'
 const openDateEnv = process.env.OPEN_DATE
 // nullを入れないと現在日時になってしまう
 const isEnvValid = dayjs(openDateEnv ?? null).isValid()

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -95,7 +95,8 @@ export default {
   },
 
   env: {
-    API_KEY: process.env.API_KEY
+    API_KEY: process.env.API_KEY,
+    OPEN_DATE: process.env.OPEN_DATE
   },
 
   // Google Font

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@nuxtjs/axios": "^5.13.6",
         "core-js": "^3.17.2",
+        "dayjs": "^1.10.7",
         "jquery": "^3.6.0",
         "nuxt": "^2.15.8",
         "nuxt-microcms-module": "^1.0.1",
@@ -17,7 +18,8 @@
         "swiper": "^5.4.5",
         "vue-awesome-swiper": "^4.1.1",
         "vue-light-timeline": "^1.0.3",
-        "vue-slick": "^1.1.16"
+        "vue-slick": "^1.1.16",
+        "vue2-flip-countdown": "^0.11.2"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.15.4",
@@ -6888,6 +6890,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
+    },
+    "node_modules/dayjs": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
@@ -19273,6 +19280,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -19612,6 +19628,14 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
+    },
+    "node_modules/vue2-flip-countdown": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/vue2-flip-countdown/-/vue2-flip-countdown-0.11.2.tgz",
+      "integrity": "sha512-BVTpYUYrz+9vJjJ79iDAiqLFZRky8xkgh+dj8Wx44FSLz3y5TOeA2KF5qIbXp3TgG4GJ/WXpBKDv4BPemBnuBQ==",
+      "dependencies": {
+        "uuid": "^3.3.2"
+      }
     },
     "node_modules/vuex": {
       "version": "3.6.2",
@@ -26405,6 +26429,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
+    },
+    "dayjs": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
     },
     "de-indent": {
       "version": "1.0.2",
@@ -35739,6 +35768,11 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
     "v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -36011,6 +36045,14 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
+    },
+    "vue2-flip-countdown": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/vue2-flip-countdown/-/vue2-flip-countdown-0.11.2.tgz",
+      "integrity": "sha512-BVTpYUYrz+9vJjJ79iDAiqLFZRky8xkgh+dj8Wx44FSLz3y5TOeA2KF5qIbXp3TgG4GJ/WXpBKDv4BPemBnuBQ==",
+      "requires": {
+        "uuid": "^3.3.2"
+      }
     },
     "vuex": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@nuxtjs/axios": "^5.13.6",
     "core-js": "^3.17.2",
+    "dayjs": "^1.10.7",
     "jquery": "^3.6.0",
     "nuxt": "^2.15.8",
     "nuxt-microcms-module": "^1.0.1",
@@ -20,7 +21,8 @@
     "swiper": "^5.4.5",
     "vue-awesome-swiper": "^4.1.1",
     "vue-light-timeline": "^1.0.3",
-    "vue-slick": "^1.1.16"
+    "vue-slick": "^1.1.16",
+    "vue2-flip-countdown": "^0.11.2"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.15.4",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <Countdown />
     <img class="h-screen w-screen object-cover" src="@/assets/img/hero.jpg" alt="岡山大学祭">
     <div v-if="isStreaming" class="container max-w-screen-xl mt-20 mx-auto relative">
       <Header title="ライブ配信" colors="bg-red-500 text-white" :icon-path="require('@/assets/img/streaming.png')" />
@@ -142,12 +143,14 @@ import Vue from 'vue'
 import CenterTitle from '@/components/CenterTitle.vue'
 import Header from '@/components/Header.vue'
 import VerticalTitle from '@/components/VerticalTitle.vue'
+import Countdown from '@/components/Countdown.vue'
 
 export default Vue.extend({
   components: {
     CenterTitle,
     Header,
-    VerticalTitle
+    VerticalTitle,
+    Countdown
   },
   data () {
     return {

--- a/plugins/vue2-flip-countdown.ts
+++ b/plugins/vue2-flip-countdown.ts
@@ -1,0 +1,4 @@
+import Vue from 'vue'
+import FlipCountdown from 'vue2-flip-countdown'
+
+Vue.use(FlipCountdown)


### PR DESCRIPTION
https://github.com/philipjkim/vue2-flip-countdown

これを使って作りました

![image](https://user-images.githubusercontent.com/74000913/135479943-3e8d2f2f-ebff-40b2-b749-a049dd4998a5.png)

11/6の0時をデフォルトにしていますが、環境変数`OPEN_DATE`に`YYYY-MM-DD HH:mm:ss`形式で日時を入れると上書きされます

setTimeoutで、オープンした瞬間にリロードします

`this.enableCountDown = false` で消えると思ったんですが消えない、なんで？