### PR TITLE
Fix: トップページの仮動画を変更

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -9,7 +9,7 @@
           <div class="relative overflow-hidden" style="padding-bottom: 56.25%">
             <iframe
               class="absolute h-full w-full"
-              src="https://www.youtube-nocookie.com/embed/mEVC3prQz0Y?controls=0"
+              src="https://www.youtube-nocookie.com/embed/pYrRwGE8LJU?controls=0"
               title="学祭2021 パフォーマンス"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowfullscreen


### PR DESCRIPTION
うまぴょい伝説から岡山大学のイメージムービーに差し替えておきました。