### PR TITLE
Fix: クイズのタイトルでbrやuタグが使えるように修正

### DIFF
--- a/pages/quiz/index.vue
+++ b/pages/quiz/index.vue
@@ -9,8 +9,9 @@
         <p class="mt-8 mb-4 text-yellow-400 text-lg font-bold">
           Question
         </p>
+        <!-- brやuタグのためにHTMLLeaderを使用 -->
         <p class="mb-4 text-xl font-bold">
-          {{ question.quiz }}
+          <HTMLLeader :body="question.quiz" />
         </p>
         <div class="mb-4 flex flex-col gap-y-3">
           <div
@@ -113,6 +114,7 @@ import Header from '@/components/layouts/Header.vue'
 import VerticalTitle from '@/components/layouts/VerticalTitle.vue'
 import BodyWithHeader from '@/components/templates/header/BodyWithHeader.vue'
 import RoundedButton from '@/components/templates/parts/RoundedButton.vue'
+import HTMLLeader from '~/components/templates/html/HTMLLeader.vue'
 
 const url = process.env.BACKEND_API_URL
 
@@ -121,7 +123,8 @@ export default Vue.extend({
     Header,
     VerticalTitle,
     BodyWithHeader,
-    RoundedButton
+    RoundedButton,
+    HTMLLeader
   },
   middleware: 'auth',
   asyncData ({ app }: Context) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/74000913/139645229-eebeda6c-aff9-4b03-aaef-d402c880c76e.png)

`HTMLLeader`コンポーネントを再利用したため、[HTMLLeader.vue](https://github.com/oucrc-org/okayama-univ-fes-2021/blob/main/components/templates/html/HTMLLeader.vue)のスタイルが影響します。ご注意ください。

