### PR TITLE
Clean: 正規表現を若干見やすく

### DIFF
--- a/components/templates/html/HTMLLeader.vue
+++ b/components/templates/html/HTMLLeader.vue
@@ -15,7 +15,7 @@ export default {
   methods: {
     fixImageRequestSize (html: string): string {
       return html.replaceAll(
-        /<img src="([^"?]+)(?:\?[^"]*)?"[^>]*>/g,
+        /<img .*?src="(.*?)\??.*?".*?>/g,
         (_, p1) => `<picture>
           <source srcset="${p1}?fm=webp&fit=clip&w=976&q=75" type="image/webp">
           <img src="${p1}?fit=clip&w=976&q=75" alt="">

--- a/components/templates/html/HTMLLeader.vue
+++ b/components/templates/html/HTMLLeader.vue
@@ -15,7 +15,7 @@ export default {
   methods: {
     fixImageRequestSize (html: string): string {
       return html.replaceAll(
-        /<img .*?src="(.*?)\??.*?".*?>/g,
+        /<img .*?src="([^?]*?)(?:\?.*?)?".*?>/g,
         (_, p1) => `<picture>
           <source srcset="${p1}?fm=webp&fit=clip&w=976&q=75" type="image/webp">
           <img src="${p1}?fit=clip&w=976&q=75" alt="">


### PR DESCRIPTION
文字集合の否定 `[^"?]+` で擬似的に最短で `"aaaa?=xxxx"` の `aaaa` の部分を取るようにしていましたが、普通に最短マッチ `[^?]*?` を使うようにしました