### PR TITLE
日時に応じて「次のイベント」切り替わるように

### DIFF
--- a/assets/data/date-next-event.ts
+++ b/assets/data/date-next-event.ts
@@ -1,0 +1,28 @@
+interface EventData {
+  // 開始時間
+  time?: string,
+
+  // イベント名。自動補完の利便化のため"t"itleにはしない
+  name?: string,
+
+  // 画像のフォルダはコンポーネントで補完
+  // webp画像名
+  webp?: string,
+
+  // jpg画像名
+  jpg?: string
+}
+
+/**
+ * 「表示を終わる時間: イベントデータ」
+ * 画像パスが重複してる理由は、「時間がなくて画像変換ができなかった」「ここだけ変えたい」と言った需要に応えるた目です
+ *
+ * @see https://github.com/oucrc-org/okayama-univ-fes-2021/blob/main/assets/data/date-youtube-url.ts
+ */
+const dateNextEvent: Record<string, EventData> = {
+  '2021-11-8 19:00': { time: '11/7（日）16:00 〜', name: 'プロライブ（ハナコ、四千頭身、ぼる塾', webp: 'burner_next_event_procon.webp', jpg: 'burner_next_event_procon.jpg' },
+  '2021-11-16 21:00': { time: '11/16（火）18:00〜', name: '校友会ステージ企画（1日目)', webp: 'burner_next_event_stage.webp', jpg: 'burner_next_event_stage.jpg' },
+  '2021-11-17 21:00': { time: '11/17（水）18:00〜', name: '校友会ステージ企画（2日目）', webp: 'burner_next_event_stage.webp', jpg: 'burner_next_event_stage.jpg' }
+}
+
+export default dateNextEvent

--- a/assets/js/event/get-next-event.ts
+++ b/assets/js/event/get-next-event.ts
@@ -1,0 +1,60 @@
+import dayjs from 'dayjs'
+// バンドルサイズ最小化のため他と同じプラグインを使う
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
+
+import 'dayjs/locale/ja'
+import dateNextEvent from '~/assets/data/date-next-event' // import locale
+
+// 地域を設定。ja-jpではなくjaを使うこと https://github.com/iamkun/dayjs/tree/dev/src/locale
+dayjs.locale('ja')
+
+// 日付を比較するプラグインを有効か
+dayjs.extend(isSameOrAfter)
+
+function sortDateStrings (dates: string[]) {
+  return dates.sort((a, b) => {
+    // dayjsの差分を使って並び替える
+    return dayjs(a).diff(dayjs(b))
+  })
+}
+
+/**
+ * 今日の日時から、最新のURL、生配信か否か、放送時間を取得する。
+ * isLiveは常に真偽を返し、それ以外は未定義の場合がある
+ */
+const getNextEvent = () => {
+  // 日時だけを配列にする
+  const dates = Object.keys(dateNextEvent)
+
+  // 今日の日付インスタンス
+  const today = dayjs()
+
+  // 次の日付だけを絞り込む
+  const datesAfterToday = dates.filter((dateString) => {
+    const dateToCompare = dayjs(dateString)
+    return !today.isSameOrAfter(dateToCompare)
+  })
+
+  // 次のイベントの日付の配列を並び替える
+  const sorted = sortDateStrings(datesAfterToday)
+
+  // 先に定義しないと描画で未定義エラーになる
+  let time, name, webp, jpg: string | undefined
+  const latest = dateNextEvent[sorted[0]]
+
+  if (latest) {
+    time = latest.time
+    name = latest.name
+    // ここで合成してrequireしないとパスを解決できない
+    webp = require(`@/assets/img/static/home/${latest.webp}`)
+    jpg = require(`@/assets/img/static/home/${latest.jpg}`)
+  }
+  return {
+    time,
+    name,
+    webp,
+    jpg
+  }
+}
+
+export default getNextEvent

--- a/components/templates/event/NextEvent.vue
+++ b/components/templates/event/NextEvent.vue
@@ -1,13 +1,14 @@
 <template>
-  <div class="hero bg-base-200 pb-4 pt-10 sm:py-10">
+  <div v-if="time && name" class="hero bg-base-200 pb-4 pt-10 sm:py-10">
     <div class="max-w-screen-lg px-2 sm:px-0">
       <LinkTo to="/live" class="flex-col hero-content lg:flex-row-reverse">
         <picture>
-          <source :srcset="require('@/assets/img/static/home/burner_next_event_procon.webp')" type="image/webp">
+          <source v-if="webp" :srcset="webp" type="image/webp">
           <img
-            src="@/assets/img/static/home/burner_next_event_procon.jpg"
+            v-if="jpg"
+            :src="jpg"
             class="shadow-xl sm:max-w-lg lg:ml-8"
-            alt="学長からのメッセージ"
+            :alt="name + 'の画像'"
           >
         </picture>
         <div>
@@ -15,10 +16,10 @@
             次のイベント
           </h1>
           <p class="mb-2 font-bold text-2xl lg:text-3xl text-accentColor">
-            11/7（日）16:00 〜
+            {{ time }}
           </p>
           <p class="mb-5 text-lg lg:text-xl text-gray-700">
-            プロライブ（ハナコ、四千頭身、ぼる塾）
+            {{ name }}
           </p>
           <LinkTo
             to="/live"
@@ -33,8 +34,17 @@
 </template>
 
 <script>
+import getNextEvent from '~/assets/js/event/get-next-event'
 export default {
-
+  data () {
+    const { time, name, jpg, webp } = getNextEvent()
+    return {
+      time,
+      name,
+      webp,
+      jpg
+    }
+  }
 }
 </script>
 

--- a/components/templates/event/NextEvent.vue
+++ b/components/templates/event/NextEvent.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="hero bg-base-200 pb-4 pt-10 sm:py-10">
+    <div class="max-w-screen-lg px-2 sm:px-0">
+      <LinkTo to="/live" class="flex-col hero-content lg:flex-row-reverse">
+        <picture>
+          <source :srcset="require('@/assets/img/static/home/burner_next_event_procon.webp')" type="image/webp">
+          <img
+            src="@/assets/img/static/home/burner_next_event_procon.jpg"
+            class="shadow-xl sm:max-w-lg lg:ml-8"
+            alt="学長からのメッセージ"
+          >
+        </picture>
+        <div>
+          <h1 class="mb-6 mt-6 lg:mt-0 text-3xl lg:text-5xl font-bold">
+            次のイベント
+          </h1>
+          <p class="mb-2 font-bold text-2xl lg:text-3xl text-accentColor">
+            11/7（日）16:00 〜
+          </p>
+          <p class="mb-5 text-lg lg:text-xl text-gray-700">
+            プロライブ（ハナコ、四千頭身、ぼる塾）
+          </p>
+          <LinkTo
+            to="/live"
+            class="border-3 border-themeColor bg-themeColor inline-block font-medium text-center text-white text-lg mt-4 tracking-wider rounded-full w-56 py-3 transform transition duration-300 hover:scale-105"
+          >
+            見に行く →
+          </LinkTo>
+        </div>
+      </LinkTo>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style>
+
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -163,41 +163,7 @@
       </div>
     </div>
     <!-- ▲ 今年の学祭について -->
-
-    <!-- ▼ 次のイベント -->
-    <div class="hero bg-base-200 pb-4 pt-10 sm:py-10">
-      <div class="max-w-screen-lg px-2 sm:px-0">
-        <LinkTo to="/live" class="flex-col hero-content lg:flex-row-reverse">
-          <picture>
-            <source :srcset="require('@/assets/img/static/home/burner_next_event_procon.webp')" type="image/webp">
-            <img
-              src="@/assets/img/static/home/burner_next_event_procon.jpg"
-              class="shadow-xl sm:max-w-lg lg:ml-8"
-              alt="学長からのメッセージ"
-            >
-          </picture>
-          <div>
-            <h1 class="mb-6 mt-6 lg:mt-0 text-3xl lg:text-5xl font-bold">
-              次のイベント
-            </h1>
-            <p class="mb-2 font-bold text-2xl lg:text-3xl text-accentColor">
-              11/7（日）16:00 〜
-            </p>
-            <p class="mb-5 text-lg lg:text-xl text-gray-700">
-              プロライブ（ハナコ、四千頭身、ぼる塾）
-            </p>
-            <LinkTo
-              to="/live"
-              class="border-3 border-themeColor bg-themeColor inline-block font-medium text-center text-white text-lg mt-4 tracking-wider rounded-full w-56 py-3 transform transition duration-300 hover:scale-105"
-            >
-              見に行く →
-            </LinkTo>
-          </div>
-        </LinkTo>
-      </div>
-    </div>
-    <!-- ▲ 次のイベント -->
-
+    <NextEvent />
     <!-- ▼ バーナー -->
     <div class="grid md:grid-cols-2 gap-6 max-w-screen-lg mt-12 mx-auto px-8">
       <a href="/president-message">
@@ -643,6 +609,7 @@ import SurveyBanner from '~/components/templates/survey/SurveyBanner.vue'
 import DailyLiveOrVideo from '~/components/templates/video/DailyLiveOrVideo.vue'
 import IResponse from '~/assets/js/type/request/IResponse'
 import ITweet from '~/assets/js/type/ITweet'
+import NextEvent from '~/components/templates/event/NextEvent.vue'
 
 interface IResponseTweets extends IResponse {
   data: {
@@ -659,7 +626,8 @@ export default Vue.extend({
     Header,
     VerticalTitle,
     DailyLiveOrVideo,
-    SurveyBanner
+    SurveyBanner,
+    NextEvent
   },
   asyncData ({ app }: Context): Promise<{ tweets: ITweet[] }> {
     return app.$axios.get(`${url}/twitter`).then((res: IResponseTweets) => {


### PR DESCRIPTION
## 11/8 19:00まで
<img src="https://user-images.githubusercontent.com/74000913/140018977-31dce03f-8509-4458-8013-8cfa7a8cc370.png" width="300" />

## 11/16 21:00まで
<img src="https://user-images.githubusercontent.com/74000913/140019105-0d4d4695-7bec-42b9-b5b1-42bef30d9cd5.png" width="300" />

## 11/17 21:00まで
<img src="https://user-images.githubusercontent.com/74000913/140019037-2f3788f8-5048-4128-92f9-2c7a6131959f.png" width="300" />

## それ以降(消える)
<img src="https://user-images.githubusercontent.com/74000913/140019309-18715a94-a42d-4964-9ab8-61f01de85b35.png" width="300" />

## Issue

- close #152 
