### PR TITLE
Add: ロード中のインジケーターを追加

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -186,5 +186,13 @@ export default {
         client_id: process.env.GOOGLE_CLIENT_ID
       }
     }
+  },
+  // ロード中のインジケーター
+  // DEMO: https://tobiasahlin.com/spinkit/
+  // 選択肢: https://nuxtjs.org/docs/configuration-glossary/configuration-loading-indicator/#built-in-indicators
+  loadingIndicator: {
+    name: 'three-bounce',
+    color: 'white',
+    background: '#0171C5'
   }
 }


### PR DESCRIPTION
`ssr:false`のため、asyncDataを使ったページでロード時間が発生し、一時的に真っ白になります。それをローディングインジケーターで誤魔化します。

![image](https://user-images.githubusercontent.com/74000913/140380819-67c1529b-a22c-46c1-9df0-9b25b2cf318e.png)

**ティーザーサイトと合わせた青の背景にしてる**んですが、気に入らなかったら変えてください。

![image](https://user-images.githubusercontent.com/74000913/140381318-5ee59795-348d-4a73-8747-bd9ee637bac4.png)

じっくり見たい場合は、ChromeのNetworkタブで`Slow 3G`を選べば、~Softbank Air~遅い回線をエミュレートできます。
## 種類

<https://nuxtjs.org/docs/configuration-glossary/configuration-loading-indicator/#built-in-indicators>

## デモサイト

https://tobiasahlin.com/spinkit/

## Issue

- close #145 