### PR TITLE
Fix: YouTube縦横比を無理やり修正

### DIFF
--- a/components/pages/clubs/oucrc/Work.vue
+++ b/components/pages/clubs/oucrc/Work.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="p-6 flex justify-start flex-col gap-y-6 bg-white rounded-xl shadow-xl">
+  <div class="p-6 flex justify-start flex-col gap-y-6 bg-white rounded-xl shadow-xl overflow-hidden">
     <div>
       <div class="flex flex-wrap mb-3">
         <h3 class="inline text-2xl font-bold border-b-4" :style="{'border-color':color ||'#0071C5'}">

--- a/components/pages/clubs/oucrc/Work.vue
+++ b/components/pages/clubs/oucrc/Work.vue
@@ -30,7 +30,7 @@
 
     <div :class="$style['oucrc_work_html']">
       <!-- リッチテキスト -->
-      <HTMLLeader :body="addClassToSoundCloudIframe(work.body_html)" />
+      <HTMLLeader :body="addClassToIframe(work.body_html)" />
     </div>
   </div>
 </template>
@@ -61,18 +61,39 @@ export default Vue.extend({
       default: '#0071C5'
     }
   },
+  mounted () {
+    const youtubeIframes = $('iframe[data-youtube]')
+    /**
+     * YouTube埋め込みを16:9にリサイズする
+     * なんでjQueryかというと、embedlyというサービスで埋め込みをしているせいで
+     * iframeが入れ子になっており、よくあるposition: relativeと擬似要素の
+     * paddingつけるやつが使えないからです。
+     * リサイズには対応してません
+     */
+    youtubeIframes.each(function () {
+      const $this = $(this)
+      const width = $this.width()
+      $this.css({ height: (width ?? 100) * 0.5625 })
+    })
+  },
   methods: {
-    addClassToSoundCloudIframe (str :string): string {
+    addClassToIframe (str :string): string {
       // 他の埋め込みに影響しないようにこうする
       // CSSではtitle属性の内容で選択できないので、仕方なくHTMLを書き換える
       // data属性はCSSで使える
-      return str.replaceAll(/title="SoundCloud(.+?)"/g, 'data-soundcloud')
+      return str.replaceAll(/title="YouTube(.+?)"/g, 'data-youtube')
+        .replaceAll(/title="SoundCloud(.+?)"/g, 'data-soundcloud')
     }
   }
 })
 </script>
 
 <style module>
+/* MicroCMSのYouTube埋め込み */
+.oucrc_work_html iframe[data-youtube] {
+
+}
+
 /* MicroCMSのサンクラ埋め込み */
 .oucrc_work_html iframe[data-soundcloud] {
   float: left;


### PR DESCRIPTION
電算研ページのYouTubeの縦横比がおかしいのを修正します。

```html
<iframe class="embedly-embed" src="https://cdn.embedly.com/widgets/media.html?src=https%3A%2F%2Fwww.youtube.com%2Fembed%2FyRrlC9BXO6U%3Ffeature%3Doembed&amp;display_name=YouTube&amp;url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DyRrlC9BXO6U&amp;image=https%3A%2F%2Fi.ytimg.com%2Fvi%2FyRrlC9BXO6U%2Fhqdefault.jpg&amp;key=d640a20a3b02484e94b4b0a08440f627&amp;type=text%2Fhtml&amp;schema=youtube" width="560" height="315" scrolling="no" data-youtube="" frameborder="0" allow="autoplay; fullscreen" allowfullscreen="true" style="height: 531px;"></iframe>
```

なんでjQueryかというと、embedlyというサービスで埋め込みをしているせいでiframeが入れ子になっており、CSSで縦横比を修正するテクニックが使えないからです。画面のリサイズには対応してません。